### PR TITLE
Fixes for Timing and Brute Force Attacks.

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ exports.sign = function(val, secret){
   if ('string' != typeof val) throw new TypeError('cookie required');
   if ('string' != typeof secret) throw new TypeError('secret required');
   return val + '.' + crypto
-    .createHmac('sha256', secret)
+    .createHmac('sha512', secret)
     .update(val)
     .digest('base64')
     .replace(/\=+$/, '');


### PR DESCRIPTION
The way you unsign cookies currently allows attackers to derive correct MACs for arbitrary values in significantly less than 1 day with a [timing attack](http://en.wikipedia.org/wiki/Timing_attack).  They can do this because JavaScript's == operator works on a byte-by-byte basis, and they can determine which bytes of the MAC are correct and incorrect with high probability.

The way I've fixed this is by using the digest twice in comparison, so that an attacker can't determine on which byte the comparison has failed.  There are other commonly accepted ways to do this, but I don't think that they would be more efficient or take less code.

Also, for simply brute forcing the MAC, the attacker has a probability of success of 1/(2^256) and an unlimited window of time to succeed.  That's why I've bumped up the algorithm from sha256 to sha512--to further discourage such things.

Sorry if I seem like I'm bringing up little issues on a dead project, but these are incredibly dangerous attacks to larger websites that use this package through Express.js.  =)
