### PR TITLE
Added repository field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository" : { 
     "type" : "git", 
     "url" : "https://github.com/visionmedia/node-cookie-signature.git"
-  }
+  },
   "author": "TJ Holowaychuk <tj@learnboost.com>",
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
While installing cookie-signature using **npm install** it is showing following warning.

``` console
npm WARN package.json cookie-signature@1.0.1 No repository field.
```

Added repository field in package.json to fix the above warning.
