### PR TITLE
Suppress NPM warning by adding repo to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "Sign and unsign cookies",
   "keywords": ["cookie", "sign", "unsign"],
   "author": "TJ Holowaychuk <tj@learnboost.com>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/visionmedia/node-cookie-signature"
+  },
   "dependencies": {},
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
npm WARN package.json cookie-signature@1.0.1 No repository field.
