### PR TITLE
Change `sha1` to `sha256` inside `unsign` method

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,13 +39,13 @@ exports.unsign = function(val, secret){
   var str = val.slice(0, val.lastIndexOf('.'))
     , mac = exports.sign(str, secret);
   
-  return sha1(mac) == sha1(val) ? str : false;
+  return sha256(mac) == sha256(val) ? str : false;
 };
 
 /**
  * Private
  */
 
-function sha1(str){
-  return crypto.createHash('sha1').update(str).digest('hex');
+function sha256(str){
+  return crypto.createHash('sha256').update(str).digest('hex');
 }


### PR DESCRIPTION
Purpose: to use a more secure encryption method in the string-comparison operation inside the `unsign` method. My organization uses the module, and the presence of `sha1` here triggered a security alert, so I wanted to see if this change could be made, please.