### PR TITLE
Remove redundant hashing step

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,8 +38,8 @@ exports.unsign = function(val, secret){
   if ('string' != typeof secret) throw new TypeError("Secret string must be provided.");
   var str = val.slice(0, val.lastIndexOf('.'))
     , mac = exports.sign(str, secret);
-  
-  return sha1(mac) == sha1(val) ? str : false;
+
+  return mac === val ? str : false;
 };
 
 /**

--- a/index.js
+++ b/index.js
@@ -45,7 +45,3 @@ exports.unsign = function(val, secret){
 /**
  * Private
  */
-
-function sha1(str){
-  return crypto.createHash('sha1').update(str).digest('hex');
-}


### PR DESCRIPTION
Comparing hash values of strings is slower than normally comparing strings with the equal operator.
