### PR TITLE
Use the tsscmp module for older Node.js compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
  */
 
 var crypto = require('crypto');
+var timingSafeCompare = require('tsscmp');
 
 /**
  * Sign the given `val` with `secret`.
@@ -37,10 +38,7 @@ exports.unsign = function(val, secret){
   if ('string' != typeof val) throw new TypeError("Signed cookie string must be provided.");
   if ('string' != typeof secret) throw new TypeError("Secret string must be provided.");
   var str = val.slice(0, val.lastIndexOf('.'))
-    , mac = exports.sign(str, secret)
-    , macBuffer = Buffer.from(mac)
-    , valBuffer = Buffer.alloc(macBuffer.length);
+    , mac = exports.sign(str, secret);
 
-  valBuffer.write(val);
-  return crypto.timingSafeEqual(macBuffer, valBuffer) ? str : false;
+  return timingSafeCompare(mac, val) ? str : false;
 };

--- a/package.json
+++ b/package.json
@@ -9,9 +9,11 @@
     "type": "git",
     "url": "https://github.com/visionmedia/node-cookie-signature.git"
   },
-  "dependencies": {},
+  "dependencies": {
+    "tsscmp": "~1.0.5"
+  },
   "engines": {
-    "node": ">=6.6.0"
+    "node": ">=0.6.0"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
This is a followup on my comment https://github.com/tj/node-cookie-signature/pull/24#issuecomment-363783627 such that Express and related modules can continue to use this module instead of needing to switch to something else for Node.js compatibility.

Please feel free to reject it if you rather not add a dependency, though. Express can fork this module and depend on a fork if needed, so no big deal, but just wanted to offer this up in case you'd like to incorporate it into the module 👍 

The `tsscmp` module was directed by a Node.js core maintainer and is a user-land port of the algo in Node.js