### PR TITLE
Avoid accepting otherwise-valid cookies when they have extra garbage appended

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,23 +24,23 @@ exports.sign = function(val, secret){
 };
 
 /**
- * Unsign and decode the given `val` with `secret`,
+ * Unsign and decode the given `input` with `secret`,
  * returning `false` if the signature is invalid.
  *
- * @param {String} val
+ * @param {String} input
  * @param {String} secret
  * @return {String|Boolean}
  * @api private
  */
 
-exports.unsign = function(val, secret){
-  if ('string' != typeof val) throw new TypeError("Signed cookie string must be provided.");
+exports.unsign = function(input, secret){
+  if ('string' != typeof input) throw new TypeError("Signed cookie string must be provided.");
   if ('string' != typeof secret) throw new TypeError("Secret string must be provided.");
-  var str = val.slice(0, val.lastIndexOf('.'))
-    , mac = exports.sign(str, secret)
-    , macBuffer = Buffer.from(mac)
-    , valBuffer = Buffer.alloc(macBuffer.length);
+  var tentativeValue = input.slice(0, input.lastIndexOf('.')),
+      expectedInput = exports.sign(tentativeValue, secret),
+      expectedBuffer = Buffer.from(expectedInput),
+      inputBuffer = Buffer.alloc(expectedBuffer.length);
 
-  valBuffer.write(val);
-  return crypto.timingSafeEqual(macBuffer, valBuffer) ? str : false;
+  inputBuffer.write(input);
+  return crypto.timingSafeEqual(expectedBuffer, inputBuffer) ? tentativeValue : false;
 };

--- a/index.js
+++ b/index.js
@@ -39,8 +39,9 @@ exports.unsign = function(input, secret){
   var tentativeValue = input.slice(0, input.lastIndexOf('.')),
       expectedInput = exports.sign(tentativeValue, secret),
       expectedBuffer = Buffer.from(expectedInput),
-      inputBuffer = Buffer.alloc(expectedBuffer.length);
-
-  inputBuffer.write(input);
-  return crypto.timingSafeEqual(expectedBuffer, inputBuffer) ? tentativeValue : false;
+      inputBuffer = Buffer.from(input);
+  return (
+    expectedBuffer.length === inputBuffer.length &&
+    crypto.timingSafeEqual(expectedBuffer, inputBuffer)
+   ) ? tentativeValue : false;
 };

--- a/test/index.js
+++ b/test/index.js
@@ -18,6 +18,6 @@ describe('.unsign(val, secret)', function(){
   it('should unsign the cookie', function(){
     var val = cookie.sign('hello', 'tobiiscool');
     cookie.unsign(val, 'tobiiscool').should.equal('hello');
-    cookie.unsign(val, 'luna').should.be.false;
+    cookie.unsign(val, 'luna').should.be.false();
   })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -20,4 +20,14 @@ describe('.unsign(val, secret)', function(){
     cookie.unsign(val, 'tobiiscool').should.equal('hello');
     cookie.unsign(val, 'luna').should.be.false();
   })
+  it('should reject malformed cookies', function(){
+    var pwd = 'actual sekrit password';
+    cookie.unsign('fake unsigned data', pwd).should.be.false();
+
+    var val = cookie.sign('real data', pwd);
+    cookie.unsign('garbage'+val, pwd).should.be.false();
+    cookie.unsign('garbage.'+val, pwd).should.be.false();
+    cookie.unsign(val+'.garbage', pwd).should.be.false();
+    cookie.unsign(val+'garbage', pwd).should.be.false();
+  })
 })


### PR DESCRIPTION
This fixes a [relatively harmless afaict] bug in that given a valid cookie like `value.a1b2c3d45` we would also return successfully for inputs like `value.a1b2c3d4555555555555` or `value.a1b2c3d45-extrajunk`.

My assessment at https://github.com/tj/node-cookie-signature/pull/24#issuecomment-358824288 was incorrect on this point:

> `mac` [the re-signed value] will always be at least as long as `val` [the untrusted input], and so there's no risk of accepting only a prefix match.

This was wrong because when the input `val` had garbage appending *in its signature portion* then it **can** be longer than `mac`. This meant we *were* accepting prefix matches after all as reported in #40. I believe this is a simple bug and not a vulnerability, as it still requires an already-valid token to begin with and any extra suffix is simply discarded.

Note that I've also combined this work with an internal renaming of all the variables for clarity (#26) — i.e. `val` in the discussion above is now `input` in this patch, and `mac` is now `expectedInput`, along with other more descriptive renames.

---

And just because this comes up every time, here https://github.com/tj/node-cookie-signature/pull/24#issuecomment-363864999 is the tl;dr; of why we are both double-hashing **and** timing-safe equal ;-)