### PR TITLE
chore: move main entry to top

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "cookie-signature",
   "version": "1.2.1",
+  "main": "index.js",
   "description": "Sign and unsign cookies",
   "keywords": ["cookie", "sign", "unsign"],
   "author": "TJ Holowaychuk <tj@learnboost.com>",
@@ -20,5 +21,4 @@
   "scripts": {
     "test": "mocha --require should --reporter spec"
   },
-  "main": "index"
 }


### PR DESCRIPTION
This is likely an esoteric request, but it'd really help us if this entry could be moved to the top of the `package.json` file. A change in Node.js (https://github.com/nodejs/node/pull/50322) moved the package.json resolution logic to C++, pulling in a C++ JSON library called simdjson.

This library is now causing ASAN crashes during package.json resolution, but only when `main` is at the end of `package.json`. It's more typical for it to be at the top, so this change is slightly more conventional but more importantly will help Electron avoid ASAN crashes as we indirectly depend on this package in our test suite.

The ASAN build is broken entirely in Node.js, so this is hitting Electron hard but Node.js itself hasn't surfaced this because Electron's embedded Node.js build works with ASAN where Node.js core does not.

Associate Node.js bug: https://github.com/nodejs/node/issues/55584